### PR TITLE
Fix DaisyUI default theme variables

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,7 +2,7 @@
 @import 'tailwind-animate';
 
 @plugin 'daisyui' {
-  themes: forest;
+  themes: forest --default;
 }
 
 @plugin 'tailwind-scrollbar';


### PR DESCRIPTION
## Summary
- Mark the DaisyUI forest theme as the default root theme.
- Restore Tailwind v4 color utilities that depend on DaisyUI `--color-*` variables.
- Fix affected text colors, button colors, and the hero `from-error` to `to-warning` gradient.

## Verification
- Ran `npm run lint`; it completed with the existing `react-hooks/exhaustive-deps` warning in `src/components/ui/stars-background.tsx`.
- Verified locally in browser that `--color-base-content`, `--color-error`, `--color-warning`, and related DaisyUI tokens resolve on `:root`.
- Confirmed the local hero text and gradient render correctly after the change.